### PR TITLE
Fix disassembly of float (and other new) literals.

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -2502,3 +2502,8 @@ Version 1.8.4, in progress
    builtin functions can now cause other kinds of aborts
 -- added caching regime for server options other than 
    .protect_<function>
+
+Version X, in progress
+-- The disassemble() built-in function will now properly disassemble all
+   possible literal values. Formerly, FLOAT literals were not properly
+   disassembled.

--- a/disassemble.c
+++ b/disassemble.c
@@ -187,7 +187,6 @@ disassemble(Program * prog, Printer p, void *data)
     int i, l;
     unsigned pc;
     Bytecodes bc;
-    const char *ptr;
     const char **names = prog->var_names;
     unsigned tmp, num_names = prog->num_var_names;
 #   define NAMES(i)	(tmp = i,					\
@@ -339,35 +338,7 @@ disassemble(Program * prog, Printer p, void *data)
 				  NAMES(ADD_BYTES(bc.numbytes_var_name)));
 		    break;
 		case OP_IMM:
-		    {
-			Var v;
-
-			v = literals[ADD_BYTES(bc.numbytes_literal)];
-			switch (v.type) {
-			case TYPE_OBJ:
-			    stream_printf(insn, " #%d", v.v.obj);
-			    break;
-			case TYPE_INT:
-			    stream_printf(insn, " %d", v.v.num);
-			    break;
-			case TYPE_STR:
-			    stream_add_string(insn, " \"");
-			    for (ptr = v.v.str; *ptr; ptr++) {
-				if (*ptr == '"' || *ptr == '\\')
-				    stream_add_char(insn, '\\');
-				stream_add_char(insn, *ptr);
-			    }
-			    stream_add_char(insn, '"');
-			    break;
-			case TYPE_ERR:
-			    stream_printf(insn, " %s", error_name(v.v.err));
-			    break;
-			default:
-			    stream_printf(insn, " <literal type = %d>",
-					  v.type);
-			    break;
-			}
-		    }
+		    unparse_value(insn, literals[ADD_BYTES(bc.numbytes_literal)]);
 		    break;
 		case OP_BI_FUNC_CALL:
 		    stream_printf(insn, " %s", name_func_by_num(ADD_BYTES(1)));


### PR DESCRIPTION
Disassemble literals with unparse_value instead of duplicating old code.
