### PR TITLE
Reserved property framework; reserve "class"

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -2295,3 +2295,9 @@ Version 1.8.0p5, 12 May 1996
 	36789.foo
    (an understandable typo for #6789.foo) stopped compiling when found in a
    database made by a pre-1.8.0 server.
+
+Version X, in progress
+**** Changes significant to people compiling and running the server:
+-- Specific property names can be reserved, preventing them from being used by
+   new or renamed properties. By default, the "class" property is blocked to
+   ensure future WAIF compatibility.

--- a/db_properties.c
+++ b/db_properties.c
@@ -117,6 +117,31 @@ insert_prop_recursively(Objid root, int root_pos, Pval pv)
     }
 }
 
+static
+char
+is_reserved_property(const char *name)
+{
+#ifdef RESERVED_PROPERTIES
+    static const char *reserved[] = {RESERVED_PROPERTIES};
+    static int hashes[Arraysize(reserved)];
+    static char hashes_init = 0;
+    int i;
+    int hash = str_hash(name);
+
+    if (!hashes_init) {
+	for (i = 0; i < Arraysize(reserved); ++i)
+	    hashes[i] = str_hash(reserved[i]);
+	hashes_init = 1;
+    }
+
+    for (i = 0; i < Arraysize(reserved); ++i)
+	if (hashes[i] == hash && !mystrcasecmp(name, reserved[i]))
+	    return 1;
+
+#endif
+    return 0;
+}
+
 int
 db_add_propdef(Objid oid, const char *pname, Var value, Objid owner,
 	       unsigned flags)
@@ -129,6 +154,9 @@ db_add_propdef(Objid oid, const char *pname, Var value, Objid owner,
     h = db_find_property(oid, pname, 0);
 
     if (h.ptr || property_defined_at_or_below(pname, str_hash(pname), oid))
+	return 0;
+
+    if (is_reserved_property(pname))
 	return 0;
 
     o = dbpriv_find_object(oid);
@@ -165,6 +193,9 @@ db_rename_propdef(Objid oid, const char *old, const char *new)
     int			count = props->cur_length;
     int			i;
     db_prop_handle	h;
+
+    if (is_reserved_property(new))
+	return 0;
 
     for (i = 0; i < count; i++) {
 	Propdef	p;

--- a/options.h
+++ b/options.h
@@ -193,6 +193,14 @@
 #define PATTERN_CACHE_SIZE	20
 
 /******************************************************************************
+ * Define this option to prevent certain property names from being added on
+ * objects. Useful to ensure forward compatibility.
+ * "class" is used by WAIFs
+ ******************************************************************************
+ */
+#define RESERVED_PROPERTIES "class"
+
+/******************************************************************************
  * This package comes with a copy of the implementation of malloc() from GNU
  * Emacs.  This is a very nice and reasonably portable implementation, but some
  * systems, notably the NeXT machine, won't allow programs to provide their own


### PR DESCRIPTION
Specific property names can be reserved, preventing them from being used by new or renamed properties.
By default, the "class" property is blocked to ensure future WAIF compatibility.
