### PR TITLE
Scattering `for' notation

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -2295,3 +2295,7 @@ Version 1.8.0p5, 12 May 1996
 	36789.foo
    (an understandable typo for #6789.foo) stopped compiling when found in a
    database made by a pre-1.8.0 server.
+
+Version X, in progress
+**** Changes relevant to programmers / wizards:
+-- Added support for scattering in `for' statements.


### PR DESCRIPTION
This is a clean rewrite of scattering `for' notation, not based on the old implementation from 2000.
It only affects the parser and unparser, compiling to the same ast/bytecode as would be with a temporary variable.
