### PR TITLE
Fixed leak in OP_RANGE_REF

### DIFF
--- a/execute.c
+++ b/execute.c
@@ -1242,6 +1242,7 @@ do {    						    	\
 		    || to.type != TYPE_INT || from.type != TYPE_INT) {
 		    free_var(to);
 		    free_var(from);
+		    free_var(base);
 		    PUSH_ERROR(E_TYPE);
 		} else {
 		    int len = (base.type == TYPE_STR ? strlen(base.v.str)


### PR DESCRIPTION
The following code causes the leak.  (`base` should be freed, along with `from` and `to`.)

```
x = {1, 2, 3, 4, 5}; return x["i"..$];
```
