### PR TITLE
Bugfix: GNU Make 3.80 doesn't like literal semicolons in dependency lists

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,10 +8,11 @@
 
 include Makefile
 
+semi=;
 version_src.h: $(shell                              \
                                                     \
   [ -x version_hook ] && {                          \
     MAKEOVERRIDES='$(subst ',$$Q,$(MAKEOVERRIDES))' \
-    ./version_hook>/dev/null;                       \
+    ./version_hook>/dev/null${semi}                 \
   } )#'
 


### PR DESCRIPTION
Workaround this by putting it in a variable, and using that variable inside the command
