### PR TITLE
Use #0:do_match to resolve nouns in commands

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -2479,6 +2479,13 @@ Version 1.8.4, in progress
    to limit the size of user-constructed lists and strings
 -- New $server_option .max_concat_catchable to govern whether
    violating new size limits causes out-of-seconds or E_QUOTA error
+-- Added support for in-DB noun resolution. During command parsing, the server
+   now calls #0:do_match(), if it exists, with args set to {"noun"} and argstr
+   set to "noun". If #0:do_match does not exist, or if the verb-call completes
+   normally and does not return an object number, or if the verb-call
+   completes abnormally (raises, suspends, aborts, or otherwise), normal
+   in-server noun continues. Note that this call is run separately for both
+   the direct and indirect objects in a command.
 
 **** Changes significant to people compiling and running the server:
 -- Source/build information that is compiled into the server now 

--- a/match.c
+++ b/match.c
@@ -146,7 +146,8 @@ db_match_object(Objid player, const char *name, Objid *match)
     args.v.list[1].type = TYPE_STR;
     args.v.list[1].v.str = str_dup(name);
 
-    if (run_server_task(player, 0, "do_match", args, name, &value)
+    if (run_server_task_in_current_id(player, 0, "do_match", args, name,
+				      &value)
 	== OUTCOME_DONE
 	&& value.type == TYPE_OBJ)
     {

--- a/match.c
+++ b/match.c
@@ -25,6 +25,7 @@
 #include "match.h"
 #include "parse_cmd.h"
 #include "storage.h"
+#include "tasks.h"
 #include "unparse.h"
 #include "utils.h"
 
@@ -113,8 +114,8 @@ match_contents(Objid player, const char *name)
 	return d.partial;
 }
 
-Objid
-match_object(Objid player, const char *name)
+static Objid
+server_match_object(Objid player, const char *name)
 {
     if (name[0] == '\0')
 	return NOTHING;
@@ -133,6 +134,12 @@ match_object(Objid player, const char *name)
     if (!mystrcasecmp(name, "here"))
 	return db_object_location(player);
     return match_contents(player, name);
+}
+
+Objid
+match_object(Objid player, const char *name)
+{
+    return server_match_object(player, name);
 }
 
 char rcsid_match[] = "$Id$";

--- a/match.c
+++ b/match.c
@@ -138,7 +138,7 @@ server_match_object(Objid player, const char *name)
 }
 
 static int
-db_match_object(Objid player, const char *name, Objid *match)
+db_match_object(Objid player, Objid handler, const char *name, Objid *match)
 {
     Var args, value;
 
@@ -146,7 +146,7 @@ db_match_object(Objid player, const char *name, Objid *match)
     args.v.list[1].type = TYPE_STR;
     args.v.list[1].v.str = str_dup(name);
 
-    if (run_server_task_in_current_id(player, 0, "do_match", args, name,
+    if (run_server_task_in_current_id(player, handler, "do_match", args, name,
 				      &value)
 	== OUTCOME_DONE
 	&& value.type == TYPE_OBJ)
@@ -162,11 +162,11 @@ db_match_object(Objid player, const char *name, Objid *match)
 }
 
 Objid
-match_object(Objid player, const char *name)
+match_object(Objid player, Objid handler, const char *name)
 {
     Objid matched;
 
-    if (db_match_object(player, name, &matched))
+    if (db_match_object(player, handler, name, &matched))
 	return matched;
     return server_match_object(player, name);
 }

--- a/match.h
+++ b/match.h
@@ -18,7 +18,7 @@
 #include "config.h"
 #include "structures.h"
 
-extern Objid match_object(Objid player, const char *name);
+extern Objid match_object(Objid player, Objid handler, const char *name);
 
 /* 
  * $Log$

--- a/parse_cmd.c
+++ b/parse_cmd.c
@@ -124,7 +124,7 @@ parse_into_wordlist(const char *command)
 }
 
 Parsed_Command *
-parse_command(const char *command, Objid user)
+parse_command(const char *command, Objid user, Objid handler)
 {
     static Parsed_Command pc;
     const char *argstr;
@@ -216,7 +216,7 @@ parse_command(const char *command, Objid user)
     if (pc.prep != PREP_NONE) {
 	pc.prepstr = build_string(pend - pstart + 1, argv + pstart);
 	pc.iobjstr = build_string(argc - (pend + 1), argv + (pend + 1));
-	pc.iobj = match_object(user, pc.iobjstr);
+	pc.iobj = match_object(user, handler, pc.iobjstr);
     } else {
 	pc.prepstr = str_dup("");
 	pc.iobjstr = str_dup("");
@@ -229,7 +229,7 @@ parse_command(const char *command, Objid user)
 	pc.dobj = NOTHING;
     } else {
 	pc.dobjstr = build_string(dlen, argv + 1);
-	pc.dobj = match_object(user, pc.dobjstr);
+	pc.dobj = match_object(user, handler, pc.dobjstr);
     }
 
     free_str(buf);

--- a/parse_cmd.h
+++ b/parse_cmd.h
@@ -39,7 +39,8 @@ typedef struct {
 
 extern char **parse_into_words(char *input, int *nwords);
 extern Var parse_into_wordlist(const char *command);
-extern Parsed_Command *parse_command(const char *command, Objid user);
+extern Parsed_Command *parse_command(const char *command, Objid user,
+				     Objid handler);
 extern void free_parsed_command(Parsed_Command *);
 
 #endif				/* !Parse_Cmd_H */

--- a/server.c
+++ b/server.c
@@ -755,7 +755,7 @@ emergency_mode()
 		db_verb_handle h;
 		const char *message, *vname;
 
-		h = find_verb_for_programming(wizard, verbref,
+		h = find_verb_for_programming(wizard, SYSTEM_OBJECT, verbref,
 					      &message, &vname);
 		printf("%s\n", message);
 		if (h.ptr) {
@@ -793,7 +793,7 @@ emergency_mode()
 		db_verb_handle h;
 		const char *message, *vname;
 
-		h = find_verb_for_programming(wizard, verbref,
+		h = find_verb_for_programming(wizard, SYSTEM_OBJECT, verbref,
 					      &message, &vname);
 		if (h.ptr)
 		    unparse_to_file(stdout, db_verb_program(h), 0, 1,
@@ -805,7 +805,7 @@ emergency_mode()
 		db_verb_handle h;
 		const char *message, *vname;
 
-		h = find_verb_for_programming(wizard, verbref,
+		h = find_verb_for_programming(wizard, SYSTEM_OBJECT, verbref,
 					      &message, &vname);
 		if (h.ptr)
 		    disassemble_to_file(stdout, db_verb_program(h));

--- a/tasks.c
+++ b/tasks.c
@@ -524,7 +524,8 @@ start_programming(tqueue * tq, char *argstr)
     db_verb_handle h;
     const char *message, *vname;
 
-    h = find_verb_for_programming(tq->player, argstr, &message, &vname);
+    h = find_verb_for_programming(tq->player, tq->handler, argstr, &message,
+				  &vname);
     notify(tq->player, message);
 
     if (h.ptr) {
@@ -686,7 +687,7 @@ do_command_task(tqueue * tq, char *command)
 	    stream_printf(tq->program_stream, "%s\n", command);
     } else {
 	start_new_task(&(tq->last_input_task_id));
-	Parsed_Command *pc = parse_command(command, tq->player);
+	Parsed_Command *pc = parse_command(command, tq->player, tq->handler);
 
 	if (!pc)
 	    return 0;
@@ -1542,7 +1543,7 @@ read_task_queue(void)
 }
 
 db_verb_handle
-find_verb_for_programming(Objid player, const char *verbref,
+find_verb_for_programming(Objid player, Objid handler, const char *verbref,
 			  const char **message, const char **vname)
 {
     char *copy = str_dup(verbref);
@@ -1570,7 +1571,7 @@ find_verb_for_programming(Objid player, const char *verbref,
     if (obj[0] == '$')
 	oid = get_system_object(obj + 1);
     else
-	oid = match_object(player, obj);
+	oid = match_object(player, handler, obj);
 
     if (!valid(oid)) {
 	switch (oid) {

--- a/tasks.c
+++ b/tasks.c
@@ -619,6 +619,14 @@ set_delimiter(char **slot, const char *string)
 }
 
 static int
+start_new_task(int *task_id)
+{
+    current_task_id = new_task_id();
+    if (task_id)
+	*task_id = current_task_id;
+}
+
+static int
 find_verb_on(Objid oid, Parsed_Command * pc, db_verb_handle * vh)
 {
     if (!valid(oid))
@@ -677,6 +685,7 @@ do_command_task(tqueue * tq, char *command)
 	else
 	    stream_printf(tq->program_stream, "%s\n", command);
     } else {
+	start_new_task(&(tq->last_input_task_id));
 	Parsed_Command *pc = parse_command(command, tq->player);
 
 	if (!pc)
@@ -695,9 +704,9 @@ do_command_task(tqueue * tq, char *command)
 		notify(tq->player, tq->output_prefix);
 
 	    args = parse_into_wordlist(command);
-	    if (run_server_task_setting_id(tq->player, tq->handler,
-					   "do_command", args, command,
-				      &result, &(tq->last_input_task_id))
+	    if (run_server_task_in_current_id(tq->player, tq->handler,
+					      "do_command", args, command,
+					      &result)
 		!= OUTCOME_DONE
 		|| is_true(result)) {
 		/* Do nothing more; we assume :do_command handled it. */
@@ -738,9 +747,9 @@ do_login_task(tqueue * tq, char *command)
 				 */
 
     args = parse_into_wordlist(command);
-    run_server_task_setting_id(tq->player, tq->handler, "do_login_command",
-			       args, command, &result,
-			       &(tq->last_input_task_id));
+    start_new_task(&(tq->last_input_task_id));
+    run_server_task_in_current_id(tq->player, tq->handler, "do_login_command",
+				  args, command, &result);
     if (tq->connected && result.type == TYPE_OBJ && is_user(result.v.obj)) {
 	Objid new_player = result.v.obj;
 	Objid old_player = tq->player;
@@ -1316,18 +1325,7 @@ enum outcome
 run_server_task(Objid player, Objid what, const char *verb, Var args,
 		const char *argstr, Var * result)
 {
-    return run_server_task_setting_id(player, what, verb, args, argstr, result,
-				      0);
-}
-
-enum outcome
-run_server_task_setting_id(Objid player, Objid what, const char *verb,
-			   Var args, const char *argstr, Var * result,
-			   int *task_id)
-{
-    current_task_id = new_task_id();
-    if (task_id)
-	*task_id = current_task_id;
+    start_new_task(0);
     return run_server_task_in_current_id(player, what, verb, args, argstr,
 					 result);
 }
@@ -1359,7 +1357,7 @@ run_server_program_task(Objid this, const char *verb, Var args, Objid vloc,
 			int debug, Objid player, const char *argstr,
 			Var * result)
 {
-    current_task_id = new_task_id();
+    start_new_task(0);
     return do_server_program_task(this, verb, args, vloc, verbname, program,
 				  progr, debug, player, argstr, result,
 				  1/*traceback*/);

--- a/tasks.c
+++ b/tasks.c
@@ -1325,11 +1325,19 @@ run_server_task_setting_id(Objid player, Objid what, const char *verb,
 			   Var args, const char *argstr, Var * result,
 			   int *task_id)
 {
-    db_verb_handle h;
-
     current_task_id = new_task_id();
     if (task_id)
 	*task_id = current_task_id;
+    return run_server_task_in_current_id(player, what, verb, args, argstr,
+					 result);
+}
+
+enum outcome
+run_server_task_in_current_id(Objid player, Objid what, const char *verb,
+			      Var args, const char *argstr, Var * result)
+{
+    db_verb_handle h;
+
     h = db_find_callable_verb(what, verb);
     if (h.ptr)
 	return do_server_verb_task(what, verb, args, h, player, argstr,

--- a/tasks.h
+++ b/tasks.h
@@ -88,6 +88,10 @@ extern enum outcome run_server_task_setting_id(Objid player, Objid what,
 					       const char *verb, Var args,
 					       const char *argstr,
 					     Var * result, int *task_id);
+extern enum outcome run_server_task_in_current_id(Objid player, Objid what,
+						  const char *verb,
+						  Var args, const char *argstr,
+						  Var * result);
 extern enum outcome run_server_program_task(Objid this, const char *verb,
 					    Var args, Objid vloc,
 					    const char *verbname,

--- a/tasks.h
+++ b/tasks.h
@@ -84,10 +84,6 @@ extern void run_ready_tasks(void);
 extern enum outcome run_server_task(Objid player, Objid what,
 				    const char *verb, Var args,
 				    const char *argstr, Var * result);
-extern enum outcome run_server_task_setting_id(Objid player, Objid what,
-					       const char *verb, Var args,
-					       const char *argstr,
-					     Var * result, int *task_id);
 extern enum outcome run_server_task_in_current_id(Objid player, Objid what,
 						  const char *verb,
 						  Var args, const char *argstr,

--- a/tasks.h
+++ b/tasks.h
@@ -102,7 +102,7 @@ extern int last_input_task_id(Objid player);
 extern void write_task_queue(void);
 extern int read_task_queue(void);
 
-extern db_verb_handle find_verb_for_programming(Objid player,
+extern db_verb_handle find_verb_for_programming(Objid player, Objid handler,
 						const char *verbref,
 						const char **message,
 						const char **vname);


### PR DESCRIPTION
This change permits in-DB code to override the server's noun-to-object matching by providing a hook (`do_match`) on the player's connection handler. As with other in-server command parsing hooks (`do_command`, `do_login_command`), the handler is controlled using the `listen` built-in.

`do_match` hooks are called with one argument (the string to be matched to a noun), and can either return non-object values to instruct the server to continue with built-in matching or return any object number to indicate matching success. To indicate a failed match, return `#-1` (`$nothing` in LambdaMOO), `#-2` (`$ambiguous_match`), or `#-3` (`$failed_match`) as appropriate, _not_ `0`. Raising an exception, suspending, or stopping to read input will also cause built-in noun matching to proceed.

The `do_match` hooks are invoked before `do_command`, and share a taskid with the rest of the input task pipeline (`do_command`, command verbs, and `huh` calls).

This was motivated by a few scenarios:
- In "game"-like rather than social MOOs, the built-in noun matching may be inappropriate: it permits references to bare object numbers, requiring every command verb to check that its direct or indirect objects are actually reachable. Putting this logic into `$do_match` makes this kind of checking more consistent and streamlines error handling (returning `$nothing` rather than invoking `huh` directly, for example).
- The built-in matching is inextensible without server patches. For example, LambdaMOO's `*name` convention for mailing lists is handled by special-case matching in mailing list commands, which have to reside on players or in the player's feature chain rather than on the mailing list object itself. Matching `*name` to mailing lists early in command parsing means mailing list verbs can live on the mailing lists themselves, and that other commands can interact with mailing lists consistently.
- Compound noun matching requires an in-DB copy of the server's noun matching for consistency. For example, in `@verb Bob:look_self tnt rxd`, `Bob:look_self` is a "compound" noun containing both the location of the verb (`Bob`) and the name of the verb. Matching the location to an object has to be done in-DB, as there's no way to invoke the server's matcher. Having the server also use an in-DB matcher means it's easier to get this kind of object matching to work consistently with command verbs than it would be by reimplementing the stock matcher in MOO. (If you think this is easy, then, without looking, do you know if `$name` strings are supported? Do you know if room contents are matched before or after player inventories?)

This change also restructures the `run_server_task…` family of functions a bit: the `_setting_id` function is gone, replaced with a `start_new_task()` function in `tasks.c`, and a new `_in_current_id` function permits hook calls to reuse the ongoing input task ID. `run_server_task` itself still starts a new taskid before calling any verbs.

An appropriate sample implementation for LambdaMOO might be

```
@verb #0:do_match tnt rxd
@program #0:do_match
{name} = args;
return $string_utils:match_object(name, player.location, player);
.
```

_It is possible to render your database unusable with this hook._ The `do_match` hook is also invoked for the `.program` builtin and for the emergency wizard mode recovery commands. If your `do_match` hook renders its location unresolvable by anyone, the following `eval` command may be able to help you recover:

```
;; info = verb_info(#0, "do_match"); info[3] = "do_match_disabled"; set_verb_info(#0, "do_match", info);
```

_It is possible to make command-handling very slow with this hook._ The hook is invoked for each of the direct and indirect objects with a full execution quota each time. This means that under the default settings, commands that need to resolve both objects can add up to ten seconds to command handling. This is unlikely, but it's a thing to be aware of when implementing this hook. The `do_match` hook is also evaluated _before_ `do_command` if both are present.
